### PR TITLE
V1.1.0

### DIFF
--- a/lib/zipcelx.js
+++ b/lib/zipcelx.js
@@ -48,9 +48,9 @@ var generateXMLWorksheet = exports.generateXMLWorksheet = function generateXMLWo
   return _worksheet2.default.replace('{placeholder}', XMLRows);
 };
 
-exports.default = function (data, reportName) {
-  if (!(0, _validator2.default)(data)) {
-    console.error('Invalid data format, see \'linkToDocs\' for supported format.');
+exports.default = function (config) {
+  if (!(0, _validator2.default)(config.sheet.data)) {
+    console.error('Invalid data format, see: https://github.com/dixieio/zipcelx/issues/1 for supported format.');
     return;
   }
 
@@ -61,10 +61,10 @@ exports.default = function (data, reportName) {
   zip.file('_rels/.rels', _rels2.default);
   zip.file('[Content_Types].xml', _Content_Types2.default);
 
-  var worksheet = generateXMLWorksheet(data);
+  var worksheet = generateXMLWorksheet(config.sheet.data);
   xl.file('worksheets/sheet1.xml', worksheet);
 
   zip.generateAsync({ type: 'blob' }).then(function (blob) {
-    _fileSaver2.default.saveAs(blob, reportName);
+    _fileSaver2.default.saveAs(blob, config.filename + '.xlsx');
   });
 };

--- a/src/zipcelx.js
+++ b/src/zipcelx.js
@@ -15,8 +15,8 @@ export const generateXMLWorksheet = (rows) => {
   return templateSheet.replace('{placeholder}', XMLRows);
 };
 
-export default (data, reportName) => {
-  if (!validator(data)) {
+export default (config) => {
+  if (!validator(config.sheet.data)) {
     console.error('Invalid data format, see \'linkToDocs\' for supported format.');
     return;
   }
@@ -28,11 +28,11 @@ export default (data, reportName) => {
   zip.file('_rels/.rels', rels);
   zip.file('[Content_Types].xml', contentTypes);
 
-  const worksheet = generateXMLWorksheet(data);
+  const worksheet = generateXMLWorksheet(config.sheet.data);
   xl.file('worksheets/sheet1.xml', worksheet);
 
   zip.generateAsync({ type: 'blob' })
     .then((blob) => {
-      FileSaver.saveAs(blob, reportName);
+      FileSaver.saveAs(blob, config.filename);
     });
 };

--- a/src/zipcelx.js
+++ b/src/zipcelx.js
@@ -17,7 +17,7 @@ export const generateXMLWorksheet = (rows) => {
 
 export default (config) => {
   if (!validator(config.sheet.data)) {
-    console.error('Invalid data format, see \'linkToDocs\' for supported format.');
+    console.error('Invalid data format, see: https://github.com/dixieio/zipcelx/issues/1 for supported format.');
     return;
   }
 
@@ -33,6 +33,6 @@ export default (config) => {
 
   zip.generateAsync({ type: 'blob' })
     .then((blob) => {
-      FileSaver.saveAs(blob, config.filename);
+      FileSaver.saveAs(blob, `${config.filename}.xlsx`);
     });
 };


### PR DESCRIPTION
resolves #1 
Missed this in the initial release and thought this was important going forward that we support a config object instead instead of a structure of and array with arrays that represents rows.