### PR TITLE
Passing the correct object to the validator.

### DIFF
--- a/src/zipcelx.js
+++ b/src/zipcelx.js
@@ -16,7 +16,7 @@ export const generateXMLWorksheet = (rows) => {
 };
 
 export default (config) => {
-  if (!validator(config.sheet.data)) {
+  if (!validator(config)) {
     return;
   }
 


### PR DESCRIPTION
Since this is just a typo I expect that I do not need to create a test that fails. Every call to `zipcelx` fails because the validator checks for `.filename` etc. on the array `config.sheet.data` instead of the object `config`. Afterwards it works perfectly, thanks for the library!